### PR TITLE
Test on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+dist: xenial
+language: python
+cache: pip
+sudo: required
+
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.7
+
+install:
+  - pip install -U pip
+  - pip install -U flake8 pytest pytest-cov codecov
+
+script:
+  # Unit tests
+  - pytest --cov dragn
+
+  # Static analysis
+  - flake8 --statistics --count
+
+after_success:
+  # Send coverage to Codecov
+  - codecov

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 dragn
 =====
 
-Dice System library (aka random.randint as dice)
+[![PyPI version](https://img.shields.io/pypi/v/dragn.svg)](https://pypi.org/project/dragn/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/dragn.svg)](https://pypi.org/project/dragn/)
+[![Build Status](https://travis-ci.org/LuRsT/dragn.svg?branch=master)](https://travis-ci.org/LuRsT/dragn)
+[![codecov](https://codecov.io/gh/LuRsT/dragn/branch/master/graph/badge.svg)](https://codecov.io/gh/LuRsT/dragn)
+[![License](https://img.shields.io/github/license/LuRsT/dragn.svg)](LICENSE)
+
+
+Dice system library (aka `random.randint` as dice).
 
 A library that makes something simple like a random integer even simpler.
 

--- a/dragn/tests/test_dice.py
+++ b/dragn/tests/test_dice.py
@@ -1,12 +1,13 @@
 from functools import partial
 
-from dragn.dice import D4, D6, D8, D10, D12, D20, roller
+from dragn.dice import D4, D6, D8, D10, D12, D20
 from dragn.dice.die_and_roller import roller
 
 
 class TestRoller:
     def test_roller_very_naive(self):
-        fake_randomness = lambda max_value, randomness: 4
+        def fake_randomness(max_value, randomness):
+            return 4
 
         result = roller(0, randomness=fake_randomness)
 


### PR DESCRIPTION
Run tests on Travis CI and send coverage to Codecov.

Example output:

* https://travis-ci.org/hugovk/dragn/builds/447034943
* https://codecov.io/gh/hugovk/dragn/tree/f993126f449e7bf623d0b3867c7efaca27c9f3e1

Notes:
* Python 3.7 requires Xenial and sudo: https://github.com/travis-ci/travis-ci/issues/9815
* Checks code against `flake8`
* Fix a couple of `flake8` findings
* Add README badges
* Coverage is 100%!

PS I liked the hat tip to https://xkcd.com/221/ :)
