### PR TITLE
Change/tumbler returning tuples

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+    - 'dragn/tests/**'

--- a/README.md
+++ b/README.md
@@ -44,20 +44,18 @@ $ pip install dragn
 ### How to use
 
 ```python
->> from dragn.dice import D6
+>> from dragn.dice import D4, D6, D8
 >>> D6()
 1
->>> from dragn.dice import D8
 >>> f"You roll the die and the result is {D8()}"
 'You roll the die and the result is 4'
 >>> f"You roll 3 dice and you get {[D8() for _ in range(3)]}"
 >>> 'You roll 3 dice and you get [3, 1, 8]'
->>> from dragn.dice import D4
 >>> four_dice = D4 * 4
->>> f"You roll 4 dice and the sum is {four_dice()}"
-'You roll 4 dice and the sum is 15'
->>> f"You roll 4 dice again and the sum is {four_dice()}"
-'You roll 4 dice again and the sum is 13'
+>>> f"You roll 4 dice and the results are {four_dice()}"
+'You roll 4 dice and the results are (4, 3, 1, 2)'
+>>> f"You roll two dice and the results are {two_dice()}"
+'You roll two dice and the results are (3, 4)'
 ```
 
 For more examples, check the [tests](https://github.com/LuRsT/dragn/blob/master/dragn/tests/test_dice.py)

--- a/dragn/tests/test_dice.py
+++ b/dragn/tests/test_dice.py
@@ -6,17 +6,20 @@ from dragn.dice.die import DieBuilder
 
 
 class TestDieBuilder:
-    def test_creating_one_die(self) -> None:
+    @staticmethod
+    def test_creating_one_die() -> None:
         my_new_die = DieBuilder(4)
 
         assert my_new_die() in range(1, 5)
 
 
 class TestDie:
-    def test_one_configured_die(self) -> None:
+    @staticmethod
+    def test_one_configured_die() -> None:
         assert D4() in range(1, 5)
 
-    def test_all_configured_dice(self) -> None:
+    @staticmethod
+    def test_all_configured_dice() -> None:
         configured_dice = {
             D4: range(1, 5),
             D6: range(1, 7),
@@ -37,53 +40,62 @@ def D1() -> Generator:
 
 
 class TestDieBuilderForMultiDie:
-    def test_creating_multi_die_by_multiplication(self, D1: DieBuilder) -> None:
+    @staticmethod
+    def test_creating_multi_die_by_multiplication(D1: DieBuilder) -> None:
         multi_die = D1 * 2
 
         assert multi_die() == (1, 1)
 
+    @staticmethod
     def test_creating_multi_die_by_multiplication_in_different_order(
-        self, D1: DieBuilder
+        D1: DieBuilder
     ) -> None:
         multi_die = 2 * D1
 
         assert multi_die() == (1, 1)
 
-    def test_creating_multi_die_by_addition(self, D1: DieBuilder) -> None:
+    @staticmethod
+    def test_creating_multi_die_by_addition(D1: DieBuilder) -> None:
         with pytest.raises(TypeError):
             1 + D1
 
+    @staticmethod
     def test_creating_multi_die_by_addition_in_different_order(
-        self, D1: DieBuilder
+        D1: DieBuilder
     ) -> None:
         with pytest.raises(TypeError):
             D1 + 1
 
+    @staticmethod
     def test_creating_multi_die_by_addition_with_another_die(
-        self, D1: DieBuilder
+        D1: DieBuilder
     ) -> None:
         multi_die = D1 + D1
 
         assert multi_die() == (1, 1)
 
+    @staticmethod
     def test_creating_multi_die_by_addition_with_another_dice(
-        self, D1: DieBuilder
+        D1: DieBuilder
     ) -> None:
         multi_die = D1 + D1 + D1
         assert multi_die() == (1, 1, 1)
 
+    @staticmethod
     def test_creating_multi_die_by_multiplication_with_another_die(
-        self, D1: DieBuilder
+        D1: DieBuilder
     ) -> None:
         with pytest.raises(TypeError):
             D1 * D1
 
-    def test_running_dice_with_multiplication_twice(self, D1: DieBuilder) -> None:
+    @staticmethod
+    def test_running_dice_with_multiplication_twice(D1: DieBuilder) -> None:
         multi_die = 3 * D6
         assert sum(multi_die()) >= 3 <= 6 * 3
         assert sum(multi_die()) >= 3 <= 6 * 3
 
-    def test_running_dice_with_addition_twice(self, D1: DieBuilder) -> None:
+    @staticmethod
+    def test_running_dice_with_addition_twice(D1: DieBuilder) -> None:
         multi_die = D6 + D6
         assert sum(multi_die()) >= 2 <= 6 * 2
         assert sum(multi_die()) >= 2 <= 6 * 2

--- a/dragn/tests/test_dice.py
+++ b/dragn/tests/test_dice.py
@@ -40,52 +40,50 @@ class TestDieBuilderForMultiDie:
     def test_creating_multi_die_by_multiplication(self, D1: DieBuilder) -> None:
         multi_die = D1 * 2
 
-        assert multi_die() == 2
+        assert multi_die() == (1, 1)
 
     def test_creating_multi_die_by_multiplication_in_different_order(
         self, D1: DieBuilder
     ) -> None:
         multi_die = 2 * D1
 
-        assert multi_die() == 2
+        assert multi_die() == (1, 1)
 
     def test_creating_multi_die_by_addition(self, D1: DieBuilder) -> None:
-        multi_die = 1 + D1
-
-        assert multi_die() == 2
+        with pytest.raises(TypeError):
+            1 + D1
 
     def test_creating_multi_die_by_addition_in_different_order(
         self, D1: DieBuilder
     ) -> None:
-        multi_die = D1 + 1
+        with pytest.raises(TypeError):
+            D1 + 1
 
-        assert multi_die() == 2
-
-    def test_creating_multi_die_by_addition_with_other_die(
+    def test_creating_multi_die_by_addition_with_another_die(
         self, D1: DieBuilder
     ) -> None:
         multi_die = D1 + D1
 
-        assert multi_die() == 2
+        assert multi_die() == (1, 1)
 
-    def test_creating_multi_die_by_addition_with_other_dice(
+    def test_creating_multi_die_by_addition_with_another_dice(
         self, D1: DieBuilder
     ) -> None:
         multi_die = D1 + D1 + D1
-        assert multi_die() == 3
+        assert multi_die() == (1, 1, 1)
 
-    def test_creating_multi_die_by_multiplication_with_other_dice(
+    def test_creating_multi_die_by_multiplication_with_another_die(
         self, D1: DieBuilder
     ) -> None:
-        multi_die = D1 * D1 * D1
-        assert multi_die() == 1
+        with pytest.raises(TypeError):
+            D1 * D1
 
     def test_running_dice_with_multiplication_twice(self, D1: DieBuilder) -> None:
         multi_die = 3 * D6
-        assert multi_die() >= 3 <= 6 * 3
-        assert multi_die() >= 3 <= 6 * 3
+        assert sum(multi_die()) >= 3 <= 6 * 3
+        assert sum(multi_die()) >= 3 <= 6 * 3
 
     def test_running_dice_with_addition_twice(self, D1: DieBuilder) -> None:
         multi_die = D6 + D6
-        assert multi_die() >= 2 <= 6 * 2
-        assert multi_die() >= 2 <= 6 * 2
+        assert sum(multi_die()) >= 2 <= 6 * 2
+        assert sum(multi_die()) >= 2 <= 6 * 2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     # Project
     name="dragn",
-    version="0.1.1",
+    version="0.2.0",
     description="A library to emulate rolling dice",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I had this idea that tumblers should return a tuple instead of the sum of all results. It's much more common to check the results individually than just the sum, and the sum doesn't really give much information about the roll anyway.

This implementation is *pretty bad*, I'm unsure how to handle the multiplication, so for now it only really works with multiplying one Die with an integer to get some number of dice.

I'll implement more use cases in next versions, for now, I'm calling this version 0.2.0.