### PR TITLE
Add operations to Tumblers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ $ pip install dragn
 'You roll 4 dice and the results are (4, 3, 1, 2)'
 >>> f"You roll two dice and the results are {two_dice()}"
 'You roll two dice and the results are (3, 4)'
+>>> dice_tower = (D6 * 2) + D4
+>>> f"You roll two D6 and a D4 and check the results {dice_tower()}"
+'You roll two D6 and a D4 and check the results (2, 2, 6)'
 ```
 
 For more examples, check the [tests](https://github.com/LuRsT/dragn/blob/master/dragn/tests/test_dice.py)

--- a/dragn/dice/tumbler.py
+++ b/dragn/dice/tumbler.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Tuple
+from itertools import chain
+from typing import Any, List, Tuple, Union
 
 
 class Tumbler:
@@ -8,6 +9,12 @@ class Tumbler:
 
     def __call__(self) -> Tuple[Any, ...]:
         raise NotImplementedError()
+
+    def __rmul__(self, other_value: Union[Any]) -> Any:
+        return MulTumbler([self for i in range(other_value)])
+
+    def __mul__(self, other_value: Union[Any]) -> Any:
+        return MulTumbler([self for i in range(other_value)])
 
 
 class SumTumbler(Tumbler):
@@ -30,8 +37,9 @@ class MulTumbler(Tumbler):
     def __init__(self, dice: List) -> None:
         super().__init__(dice)
 
-        if not len(self.callables) or not len(self.ints):
-            raise TypeError("Cannot multiply callables in MulTumbler")
-
     def __call__(self) -> Tuple[Any, ...]:
-        return tuple([self.callables[0]() for _ in range(self.ints[0])])
+        if self.ints and self.callables:
+            return tuple([self.callables[0]() for _ in range(self.ints[0])])
+        else:
+            results = chain.from_iterable([c() for c in self.callables])
+            return tuple(results)

--- a/dragn/dice/tumbler.py
+++ b/dragn/dice/tumbler.py
@@ -16,6 +16,9 @@ class Tumbler:
     def __mul__(self, other_value: Union[Any]) -> Any:
         return MulTumbler([self for i in range(other_value)])
 
+    def __add__(self, other_value: Union[Any]) -> Any:
+        return SumTumbler([self, other_value])
+
 
 class SumTumbler(Tumbler):
     def __init__(self, dice: List) -> None:
@@ -25,12 +28,15 @@ class SumTumbler(Tumbler):
             raise TypeError("Cannot use integers in SumTumbler")
 
     def __call__(self) -> Tuple[Any, ...]:
-        dice = [die for die in self.callables if not isinstance(die, SumTumbler)]
-        tumblers = [
-            tumbler for tumbler in self.callables if isinstance(tumbler, SumTumbler)
-        ]
+        def is_a_tumbler(d: Any) -> bool:
+            return isinstance(d, SumTumbler) or isinstance(d, MulTumbler)
 
-        return tuple([d() for d in dice]) + tuple(*[t() for t in tumblers])
+        dice = [c for c in self.callables if not is_a_tumbler(c)]
+        tumblers = [c for c in self.callables if is_a_tumbler(c)]
+
+        dice_results = tuple([d() for d in dice])
+        tumbler_results = tuple(chain.from_iterable([t() for t in tumblers]))
+        return dice_results + tumbler_results
 
 
 class MulTumbler(Tumbler):

--- a/dragn/tests/test_dice.py
+++ b/dragn/tests/test_dice.py
@@ -39,44 +39,44 @@ def D1() -> Generator:
     yield DieBuilder(1)
 
 
-class TestDieBuilderForMultiDie:
+class TestDieBuilderForTumbler:
     @staticmethod
-    def test_creating_multi_die_by_multiplication(D1: DieBuilder) -> None:
-        multi_die = D1 * 2
+    def test_creating_tumbler_by_multiplication(D1: DieBuilder) -> None:
+        tumbler = D1 * 2
 
-        assert multi_die() == (1, 1)
+        assert tumbler() == (1, 1)
 
     @staticmethod
-    def test_creating_multi_die_by_multiplication_in_different_order(
+    def test_creating_tumbler_by_multiplication_in_different_order(
         D1: DieBuilder
     ) -> None:
-        multi_die = 2 * D1
+        tumbler = 2 * D1
 
-        assert multi_die() == (1, 1)
+        assert tumbler() == (1, 1)
 
     @staticmethod
-    def test_creating_multi_die_by_addition(D1: DieBuilder) -> None:
+    def test_creating_tumbler_by_addition(D1: DieBuilder) -> None:
         with pytest.raises(TypeError):
             1 + D1
 
     @staticmethod
-    def test_creating_multi_die_by_addition_in_different_order(D1: DieBuilder) -> None:
+    def test_creating_tumbler_by_addition_in_different_order(D1: DieBuilder) -> None:
         with pytest.raises(TypeError):
             D1 + 1
 
     @staticmethod
-    def test_creating_multi_die_by_addition_with_another_die(D1: DieBuilder) -> None:
-        multi_die = D1 + D1
+    def test_creating_tumbler_by_addition_with_another_die(D1: DieBuilder) -> None:
+        tumbler = D1 + D1
 
-        assert multi_die() == (1, 1)
-
-    @staticmethod
-    def test_creating_multi_die_by_addition_with_another_dice(D1: DieBuilder) -> None:
-        multi_die = D1 + D1 + D1
-        assert multi_die() == (1, 1, 1)
+        assert tumbler() == (1, 1)
 
     @staticmethod
-    def test_creating_multi_die_by_multiplication_with_another_die(
+    def test_creating_tumbler_by_addition_with_another_dice(D1: DieBuilder) -> None:
+        tumbler = D1 + D1 + D1
+        assert tumbler() == (1, 1, 1)
+
+    @staticmethod
+    def test_creating_tumbler_by_multiplication_with_another_die(
         D1: DieBuilder
     ) -> None:
         with pytest.raises(TypeError):
@@ -84,12 +84,12 @@ class TestDieBuilderForMultiDie:
 
     @staticmethod
     def test_running_dice_with_multiplication_twice(D1: DieBuilder) -> None:
-        multi_die = 3 * D6
-        assert sum(multi_die()) >= 3 <= 6 * 3
-        assert sum(multi_die()) >= 3 <= 6 * 3
+        tumbler = 3 * D6
+        assert sum(tumbler()) >= 3 <= 6 * 3
+        assert sum(tumbler()) >= 3 <= 6 * 3
 
     @staticmethod
     def test_running_dice_with_addition_twice(D1: DieBuilder) -> None:
-        multi_die = D6 + D6
-        assert sum(multi_die()) >= 2 <= 6 * 2
-        assert sum(multi_die()) >= 2 <= 6 * 2
+        tumbler = D6 + D6
+        assert sum(tumbler()) >= 2 <= 6 * 2
+        assert sum(tumbler()) >= 2 <= 6 * 2

--- a/dragn/tests/test_dice.py
+++ b/dragn/tests/test_dice.py
@@ -100,3 +100,9 @@ class TestDieBuilderForTumbler:
         tumbler = (1 * D1) * 2
 
         assert tumbler() == (1, 1)
+
+    @staticmethod
+    def test_creating_tumbler_by_adding_a_tumbler(D1: DieBuilder) -> None:
+        tumbler = (1 * D1) + (1 * D1)
+
+        assert tumbler() == (1, 1)

--- a/dragn/tests/test_dice.py
+++ b/dragn/tests/test_dice.py
@@ -60,24 +60,18 @@ class TestDieBuilderForMultiDie:
             1 + D1
 
     @staticmethod
-    def test_creating_multi_die_by_addition_in_different_order(
-        D1: DieBuilder
-    ) -> None:
+    def test_creating_multi_die_by_addition_in_different_order(D1: DieBuilder) -> None:
         with pytest.raises(TypeError):
             D1 + 1
 
     @staticmethod
-    def test_creating_multi_die_by_addition_with_another_die(
-        D1: DieBuilder
-    ) -> None:
+    def test_creating_multi_die_by_addition_with_another_die(D1: DieBuilder) -> None:
         multi_die = D1 + D1
 
         assert multi_die() == (1, 1)
 
     @staticmethod
-    def test_creating_multi_die_by_addition_with_another_dice(
-        D1: DieBuilder
-    ) -> None:
+    def test_creating_multi_die_by_addition_with_another_dice(D1: DieBuilder) -> None:
         multi_die = D1 + D1 + D1
         assert multi_die() == (1, 1, 1)
 

--- a/dragn/tests/test_dice.py
+++ b/dragn/tests/test_dice.py
@@ -76,13 +76,6 @@ class TestDieBuilderForTumbler:
         assert tumbler() == (1, 1, 1)
 
     @staticmethod
-    def test_creating_tumbler_by_multiplication_with_another_die(
-        D1: DieBuilder
-    ) -> None:
-        with pytest.raises(TypeError):
-            D1 * D1
-
-    @staticmethod
     def test_running_dice_with_multiplication_twice(D1: DieBuilder) -> None:
         tumbler = 3 * D6
         assert sum(tumbler()) >= 3 <= 6 * 3
@@ -93,3 +86,17 @@ class TestDieBuilderForTumbler:
         tumbler = D6 + D6
         assert sum(tumbler()) >= 2 <= 6 * 2
         assert sum(tumbler()) >= 2 <= 6 * 2
+
+    @staticmethod
+    def test_creating_tumbler_by_multiplying_a_tumbler(D1: DieBuilder) -> None:
+        tumbler = 2 * (1 * D1)
+
+        assert tumbler() == (1, 1)
+
+    @staticmethod
+    def test_creating_tumbler_by_multiplying_a_tumbler_other_way(
+        D1: DieBuilder
+    ) -> None:
+        tumbler = (1 * D1) * 2
+
+        assert tumbler() == (1, 1)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     # Project
     name="dragn",
-    version="0.2.0",
+    version="0.3.0",
     description="A library to emulate rolling dice",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Initial operations for tumblers. There may be some cases where you may want to add two tumblers, or even multiply them. This PR implements the initial operations for version 0.3.0